### PR TITLE
projects: Add jetbrains ide plugin project

### DIFF
--- a/data/projects.js
+++ b/data/projects.js
@@ -401,5 +401,24 @@ coala should support generating metrics for your code.",
 		"tags" : ["Documentation", "Bears", "Testing"],
 		"markdown": "generic_bears.md",
 		"collaborating_projects" : ["coala"]
+	},
+	{
+		"name" : "Plugin for jetbrains IDEs",
+		"desc" : "Offer a general mechanism of highlighting code analysis results from external \
+		tools in jetbrain IDE, the primary goal is to support coala. ",
+		"requirements" : [
+				"The applicant should have at least one patch accepted to any of the coala \
+				plugins.",
+				"The applicant shoule be familiar with jetbrains IDEs, e.g. PyCharm, IntelliJ IDEA."
+		],
+		"difficulty" : "high",
+		"issues" : [
+			"https://github.com/coala/coala/issues/2019"
+		],
+		"mentors" : ["traff"],
+		"initiatives" : ["GSoC", "RGSoC"],
+		"tags" : ["Jetbrains IDEs", "Plugins"],
+		"markdown": "jetbrains-ide-plugin.md",
+		"collaborating_projects" : ["coala", "jetbrains"]
 	}
 ]

--- a/data/projects/jetbrains-ide-plugin.md
+++ b/data/projects/jetbrains-ide-plugin.md
@@ -1,0 +1,38 @@
+JetBrains is a software vendor specializing in the creation of intelligent development tools. JetBrains IDEs 
+includes IntelliJ IDEA, PyCharm, CLion, Gogland and so on.
+
+The idea behind the support of coala is that it's better to have a general mechanism of highlighting code analysis results from external tools. (By the way, pycharm already have something similar for PEP8) Of course the primary goal is to support coala, but the API should be done in a way to be able to support others.
+
+So The project is divided into two parts:
+
+1. Have a general mechanism of highlighting code analysis results from external tools.
+2. Offer a plugin to support coala.
+
+##### Features
+
+* Implement a linter for languages supported by coala.
+* Support all jetbrains IDEs.
+* (Long-term, not in this project) Support for automatically formatting code.
+* (Long-term, not in this project) Coafile support.
+	* Support coafile syntax highlight.
+	* Coloring files that should be checked in the Project View.
+	* Support templates.
+
+#### Milestones
+
+##### GSOC 2017 CODING STARTS
+
+* A concept exists for how to support showing result for code analysis tools.
+* A Mock plugin set up.
+
+##### GSOC 2017 MIDTERM
+
+* A working plugin with minimal functionality exists.
+* Corresponding test cases exists.
+* Corresponding documentation exists.
+
+##### GSOC 2017 FINAL
+
+* A working plugin with full functionality exists.
+* A full covering testsuite exists.
+* Full Documentation exists.


### PR DESCRIPTION
New project: coala plugin for jetbrains IDEs

### Related issues

https://github.com/coala/coala/issues/2019

#### Chat in [gitter.im/coala/coala/gsoc](https://gitter.im/coala/coala/gsoc)
```text
Ce Gao @gaocegege 17:56
Hi, could we add coala/coala#2019 to projects.coala.io? There are many people use jetbrains IDEs.  It makes sense.

Lasse Schuirmann @sils 17:57
yeah certainly, we'd also have a comentor from jetbrains, can you make a project? I'll contact him

Ce Gao @gaocegege 17:58
Of course

Lasse Schuirmann @sils 17:59
contacted jetbrains, check. We might well get a comentor from them
```
Signed-off-by: Ce Gao <ce.gao@outlook.com>