### PR TITLE
debug_profile.md: corrected grammar removed "is"

### DIFF
--- a/data/projects/debug_profile.md
+++ b/data/projects/debug_profile.md
@@ -25,7 +25,7 @@ benefit of better quality Bears being contributed to the community.
 
 ##### PREPARATION/BONDING
 
-* The applicant is has gone through the [pdb docuemntation](https://docs.python.org/3.4/library/pdb.html).
+* The applicant has gone through the [pdb docuemntation](https://docs.python.org/3.4/library/pdb.html).
 * The applicant has made a [cEP](https://coala.io/cep) of how the profiling
   will be implemented has been merged.
 


### PR DESCRIPTION
Under milestones -> participation/bonding -> The applicant is has gone through the pdb docuemntation.
Removed  "is"
closes #211

### Checklist

- [ x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!
