### PR TITLE
projects.js: Fix coala-quickstart project filename

### DIFF
--- a/data/projects.js
+++ b/data/projects.js
@@ -559,7 +559,7 @@ coala should support generating metrics for your code.",
 	  ],
 	  "initiatives" : ["GSoC", "RGSoC"],
 	  "tags" : ["Information Extraction", "CLI", "CI"],
-	  "markdown" : "enhancing_coala_quickstart.md",
+	  "markdown" : "enhance_coala_quickstart.md",
 	  "collaborating_projects" : ["coala"]
 	}
 ]


### PR DESCRIPTION
In the project.js file updated the old file name to new file name so that it won't
appear blank in the frontend.

Fixes https://github.com/coala/projects/issues/261