### PR TITLE
correct typo `Succesful` -> `Successful` in antlr_v4.md

### DIFF
--- a/data/projects/antlr_v4.md
+++ b/data/projects/antlr_v4.md
@@ -14,7 +14,7 @@ they provide.
 
 Hence this project has two targets:
 
-- Succesful integration of ANTLR into the coala core providing the user with an AST interface when writing a Bear.
+- Successful integration of ANTLR into the coala core providing the user with an AST interface when writing a Bear.
 - Writing a basic Bear which tests this functionality using the AST.
 
 References:


### PR DESCRIPTION
Fixes #263
Typo in data/projects/antlr_v4.md

