### PR TITLE
_projects: Fix trailing whitespace in YAML markers

### DIFF
--- a/_projects/antlr_v4.md
+++ b/_projects/antlr_v4.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
   - ANTLRv4

--- a/_projects/aspects.md
+++ b/_projects/aspects.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "This project is about collecting bears based on aspects that the user wants to have checked."

--- a/_projects/bear_updates.md
+++ b/_projects/bear_updates.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "Fixing issues and improving documentation and testing of existing linter bears."

--- a/_projects/coala_web.md
+++ b/_projects/coala_web.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "This project aims to intensify usage of coala by developing well organised web interfaces."

--- a/_projects/cobot_enhancement.md
+++ b/_projects/cobot_enhancement.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "Port cobot to errbot, test the new plugins, and introduce new useful features"

--- a/_projects/commit_based_perftest.md
+++ b/_projects/commit_based_perftest.md
@@ -1,4 +1,4 @@
---- 
+---
 desc: "A technique to view the performance of a piece of software and automatically identify and classify performance drops and gains."
 developers_involved: []
 difficulty: medium

--- a/_projects/communication_bridge.md
+++ b/_projects/communication_bridge.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "A way to post CI problems to online team rooms, such as IRC, Telegram, slack or gitter."

--- a/_projects/debug_profile.md
+++ b/_projects/debug_profile.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "coala should support developers of code analysis by providing facilities to debug and profile bears."

--- a/_projects/documentation_extraction.md
+++ b/_projects/documentation_extraction.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "The Project is about writing language independent documentation extraction and parsing algorithms."

--- a/_projects/editor_support.md
+++ b/_projects/editor_support.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 status: in_progress

--- a/_projects/enhance_coala_quickstart.md
+++ b/_projects/enhance_coala_quickstart.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "Extract useful data from a project's configuration files to build a relevant `.coafile`."

--- a/_projects/extend_linter_integration.md
+++ b/_projects/extend_linter_integration.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "This project enhances our linter framework and creates a number of third party tool integrations."

--- a/_projects/generic_bears.md
+++ b/_projects/generic_bears.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "The project is about fixing Issues with Generic Bears and providing better API."

--- a/_projects/gitmate_gitlab.md
+++ b/_projects/gitmate_gitlab.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
   - GitMate

--- a/_projects/implement_aspects.md
+++ b/_projects/implement_aspects.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "This project is about annotating results of bears with ``aspects`` which are like categories allowing to group results."

--- a/_projects/implement_metrics_for_coala.md
+++ b/_projects/implement_metrics_for_coala.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "There is more to software quality than just passing builds - coala should support generating metrics for your code."

--- a/_projects/improve_diff_handling.md
+++ b/_projects/improve_diff_handling.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "Bears should be able to offer more than just one possible patch for an issue."

--- a/_projects/integrate-pyflakes-AST.md
+++ b/_projects/integrate-pyflakes-AST.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
   - Pyflakes

--- a/_projects/jetbrains-ide-plugin.md
+++ b/_projects/jetbrains-ide-plugin.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
   - jetbrains

--- a/_projects/nested_languages.md
+++ b/_projects/nested_languages.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "Multiple programming languages can coexist in the same source file - coala should support writing code analysis that only works on parts of files."

--- a/_projects/newcomer_metrics.md
+++ b/_projects/newcomer_metrics.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "Provide public metrics about newcomers and the newcomer process."

--- a/_projects/optimize_caching.md
+++ b/_projects/optimize_caching.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
 desc: "Improve coala's performance by improving file caching and other performance bottlenecks."

--- a/_projects/pr_perftest.md
+++ b/_projects/pr_perftest.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
   - GitMate

--- a/_projects/roberta_external_source.md
+++ b/_projects/roberta_external_source.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
   - openroberta

--- a/_projects/rstcheck_with_better_sphinx_support.md
+++ b/_projects/rstcheck_with_better_sphinx_support.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
   - rstcheck

--- a/_projects/use_coala.md
+++ b/_projects/use_coala.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - docker-coala-base
 desc: "Use coala CI on a popular GitHub project, of your choice, using a Docker image on Travis CI, and report the results to the coala developers."

--- a/_projects/use_coala_2.md
+++ b/_projects/use_coala_2.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - docker-coala-base
 desc: "Fix a popular GitHub project so that the repository contents conform to linter rules that are verified by coala CI on each commit using Travis CI."

--- a/_projects/use_coala_3.md
+++ b/_projects/use_coala_3.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - docker-coala-base
 desc: "Implement coala CI on a popular GitHub project, of your choice, using a Docker image on Travis CI, and report the results to the coala developers."

--- a/_projects/vulture.md
+++ b/_projects/vulture.md
@@ -1,4 +1,4 @@
---- 
+---
 collaborating_projects: 
   - coala
   - vulture


### PR DESCRIPTION
GitBook does not understand YAML document start markers
that have trailing whitespace.

Fixes https://github.com/coala/projects/issues/386
