### PR TITLE
Change cursor to pointer when hovering over materialize chips

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -62,3 +62,7 @@
       width: 90% !important;
   }
 }
+
+div.card > div.card-action > span.chip {
+  cursor: pointer;
+}


### PR DESCRIPTION
css/materialize.css: Change cursor to pointer when hovering over materialize chips

    Adds pointer type cursor to chips so that user know that they are
    clickable.

Closes https://github.com/coala/projects/issues/417