### PR TITLE
Update GSoC further information link in writing-a-great-proposal.md

### DIFF
--- a/_faq/writing-a-great-proposal.md
+++ b/_faq/writing-a-great-proposal.md
@@ -25,4 +25,4 @@ Please follow the **application template** in the faq. All fields are required i
 
 For writing your proposal we recommend using [Google Docs](https://www.google.com/docs/about/) as this will be supported by the Google submission system.
 
-If needed, you can get further information about GSoC [here](http://write.flossmanuals.net/gsocstudentguide/what-is-google-summer-of-code/).
+If needed, you can get further information about GSoC [here](https://developers.google.com/open-source/gsoc/resources/guide).


### PR DESCRIPTION
_faq/writing-a-great-proposal.md : Update GSoC further information link in FAQs.

This commit updates the link for GSoC further information in _faq/writing-a great-proposal.md to https://developers.google.com/open-source/gsoc/resources/guide.

Fix issue #642