### PR TITLE
application-template.md: Make GSoC application template dynamic

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,8 @@ baseurl: ""  # the subpath of your site, e.g. /blog
 url: ""  # the base hostname & protocol for your site
 githuburl: "https://github.com/coala/projects"
 
+gsoc_switch_month: 6
+
 plugins:
   - jekyll-netlify
 

--- a/_faq/application-template.md
+++ b/_faq/application-template.md
@@ -1,8 +1,12 @@
 ---
 question: "Do you have an application template?"
 ---
-coala 2018 Application Template
-===============================
+{% assign month = "now" | date: "%-m" | plus: 0 %}
+{% if month >= site.gsoc_switch_month %}
+# coala {{ "now" | date: "%Y" | plus: 1 }} Application Template
+{% else %}
+# coala {{ "now" | date: "%Y" }} Application Template
+{% endif %}
 
 ```
 Student Info


### PR DESCRIPTION
Have the year on the GSoC application template on the FAQ page change based on the month. If it's past September, the page will show the next year, otherwise it will show the current year.

Closes https://github.com/coala/projects/issues/671