### PR TITLE
projects.html: Added GSoC project reports link

### DIFF
--- a/partials/tabs/projects.html
+++ b/partials/tabs/projects.html
@@ -9,6 +9,8 @@ therefore adding an ignore comment -->
         <input ng-model="searchText" placeholder="Search for a project" id="search" type="search" class="validate"> </div>
       <div style="text-align: center;">
         For more project ideas, <a href="https://github.com/coala/projects/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Project+Proposal%22">click here</a>.
+        <br>
+        For past years <strong>GSoC</strong> project reports, <a href="http://projects.coala.io/reports">click here</a>.
       </div>
     </div>
   </div>


### PR DESCRIPTION
The following commit adds a link of past years **GSoC project reports** in projects.html, just below the project ideas [link](https://projects.coala.io/#/projects) under the search bar.

Fixes https://github.com/coala/projects/issues/683

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
