### PR TITLE
reports: Display sha256sum on webpage

### DIFF
--- a/_layouts/report.md
+++ b/_layouts/report.md
@@ -82,6 +82,14 @@
                             <div class="center"><h5 class="light no-margin">Patches Tarball</h5></div>
                             <br>
                             <div class="center"><a href="{{ page.tarball }}">Download</a></div>
+                            <br>
+                            <div class="center sha256sum_hash">
+                                <strong>SHA-256</strong>:
+                                <p id="sha256sum_hash_value">
+                                    {{page.sha256sum}}
+                                </p>
+                                <i class="fa fa-clipboard" aria-hidden="true"><span class="hinttext">Copy Hash value</span></i>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -147,5 +155,21 @@
             </div>
             <br><br>
         </div>
+        <script>
+        $('document').ready(function(){
+            var hash_value = document.getElementById('sha256sum_hash_value').textContent.trim();
+            document.getElementById('sha256sum_hash_value').textContent = hash_value.substring(0,7);
+            document.querySelector('.fa-clipboard').addEventListener('click', function(){
+                var new_element = document.createElement('textarea');
+                $('new_element:first').addClass('hash_value_dup');
+                new_element.value = hash_value;
+                new_element.setAttribute('readonly', '');
+                document.body.appendChild(new_element);
+                new_element.select();
+                document.execCommand('copy');
+                document.body.removeChild(new_element);
+                });
+        })
+        </script>
     </body>
 </html>

--- a/_reports/AlexMaxim.md
+++ b/_reports/AlexMaxim.md
@@ -11,6 +11,7 @@ organisation_link : https://coala.io
 project: Improve the coala CLI
 project_link: https://summerofcode.withgoogle.com/projects/#4940869170888704
 tarball: https://rawgit.com/Nosferatul/GSoCReport/master/Nosferatul_coala.tar
+sha256sum: ad04739a67b822ee73b764d78554a47615450321bc52a996b04a136e99fe37f9
 mentors: >
  [Adrian Zatreanu](https://github.com/Adrianzatreanu) & [Muhammad Kaisar Arkhan](https://github.com/yukiisbored)
 phase:

--- a/_reports/HemangKumar.md
+++ b/_reports/HemangKumar.md
@@ -10,6 +10,7 @@ organisation_link : https://coala.io
 project: Improve coala Website & Supporting Tools
 project_link: https://summerofcode.withgoogle.com/projects/#6012382913495040
 tarball: https://github.com/hemangsk/GSoCReport/raw/master/hemangsk_coala.tar
+sha256sum: 8ecf7e3155a764db16c21652943bdcde70a40865fcc7dc5f20f5e56dee48de09
 mentors: >
  [Lasse Schuirmann](https://github.com/sils) & [Fabian Neuschmidt](https://github.com/fneu)
 phase:

--- a/_reports/MeetMangukiya.md
+++ b/_reports/MeetMangukiya.md
@@ -10,6 +10,7 @@ organisation_link: https://coala.io
 project: cobot enhancement, testing and porting
 project_link: https://summerofcode.withgoogle.com/projects/#4913450777051136
 tarball: https://rawgit.com/meetmangukiya/GSoCReport/master/patches.tar
+sha256sum: cf47c2ae5a3b450c547d8e49c284703d7f1698699c927ede4ae8abbe7b46e1b7
 mentors: >
  [Udayan Tandon](https://github.com/udayan12167) & [Dmytro Sadovnychyi](https://github.com/sadovnychyi)
 phase:

--- a/_reports/NaveenKumarSangi.md
+++ b/_reports/NaveenKumarSangi.md
@@ -10,6 +10,7 @@ organisation_link: https://coala.io
 project: Extending GitMatev2.0 to support GitLab and Bitbucket
 project_link: https://summerofcode.withgoogle.com/projects/#4985377849868288
 tarball: https://rawgit.com/nkprince007/GSoCReport/master/project.tar
+sha256sum: 320d138d599bc8fe6cb7a109f1f78f0dc24f30dc1c8fcf3f18240d32cd4573ca
 mentors: >
  [Lasse Schuirmann](https://github.com/sils) & [Fabian Neuschmidt](https://github.com/fneu)
 phase:

--- a/_reports/RahulJha.md
+++ b/_reports/RahulJha.md
@@ -10,6 +10,7 @@ organisation_link : https://coala.io
 project: Removing dead code with Vulture
 project_link: https://summerofcode.withgoogle.com/projects/#6564412442804224
 tarball: https://github.com/RJ722/vulture/files/1255118/GSoC_RJ722_Rahul_Jha.tar.gz
+sha256sum: 7190862f40822b83b020c5db2d3d6db6b065829c90171710bf48cd5112cdeb6a
 mentors: >
  [Jendrik Seipp](https://github.com/jendrikseipp)
 phase:

--- a/_reports/adhikasp.md
+++ b/_reports/adhikasp.md
@@ -10,6 +10,7 @@ organisation_link : https://coala.io
 project: Implement Aspect
 project_link: https://summerofcode.withgoogle.com/projects/#5847850440196096
 tarball: https://rawgit.com/adhikasp/GSoC-2017-Report/master/adhikasp_tarball.tar.gz
+sha256sum: c3b80d5e1dcc5d30ca2409267d56d978abfb0ccb7f1d05abb77b208cda1ab2b9
 mentors: >
  [John Vandenberg](http://github.com/jayvdb),
  [Stefan Zimmermann](https://github.com/userzimmermann),

--- a/_reports/macbox7.md
+++ b/_reports/macbox7.md
@@ -10,6 +10,7 @@ organisation_link: https://coala.io
 project: Integrate pyflakes-enhanced AST into coala
 project_link: https://summerofcode.withgoogle.com/projects/#5549789140221952
 tarball: https://rawgit.com/MacBox7/GSoC-Report/master/project.tar.gz
+sha256sum: cf0c8e3daded8b61384a7ebf7d5ce17b535ce165f9e4694c986f1bf9e4ab9e68
 mentors: >
  [John Vandenberg](https://github.com/jayvdb),
  [Adhika Setya Pramudita](https://github.com/adhikasp),

--- a/_reports/satwikkansal.md
+++ b/_reports/satwikkansal.md
@@ -10,6 +10,7 @@ organisation_link: https://coala.io
 project: Enhance coala-quickstart
 project_link: https://summerofcode.withgoogle.com/projects/#4853947354316800
 tarball: https://rawgit.com/satwikkansal/GSoC-Report/master/patches.tar
+sha256sum: 0296b7a4c12e367b0ef27c02595f93069805c69b6a3d59f3e41e64a105c7f393
 mentors: >
  [Adhityaa](https://github.com/adtac) & [Zatreanu Adrian-Gabriel](https://github.com/Adrianzatreanu)
 phase:

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -1,3 +1,41 @@
+.hash_value_dup {
+  position: 'absolute';
+  left: '-9999px';
+}
+.hinttext {
+  visibility: hidden;
+  width: 120px;
+  background-color: gray;
+  color: #fff;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+  position: absolute;
+  z-index: 1;
+  top: 95%;
+  left: 60%;
+  margin-left: -60px;
+}
+.hinttext::after {
+  content: " ";
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent transparent gray transparent;
+}
+.fa-clipboard:hover {
+  cursor: pointer;
+}
+.fa-clipboard:hover .hinttext {
+  visibility: visible;
+}
+.project-detail-element > .clickable:hover, .clickable:hover .chip:hover {
+  cursor: pointer;
+  background-color: #f3f5f8;
+}
 .report .card {
   box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.0), 0 1px 1px 0 rgba(0, 0, 0, 0.0), 0 1px 1px 0px rgba(0, 0, 0, 0.05);
   margin-bottom: 0 !important;
@@ -70,18 +108,21 @@
     display: none;
   }
 }
-.theatre .name {
-  padding-left: 0.5em;
-  padding-right: 0.5em;
-}
-
-.project-detail-element > .clickable:hover, .clickable:hover .chip:hover {
-  cursor: pointer;
-  background-color: #f3f5f8;
-}
 .ribbon {
   position: absolute;
   top: 0; right: 0;
   border: 0;
   z-index: 9;
+}
+.sha256sum_hash {
+  display: flex;
+  justify-content: space-evenly;
+}
+.theatre .name {
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+}
+
+#sha256sum_hash_value {
+  word-wrap: break-word;
 }


### PR DESCRIPTION
As per issue, I have added the computed sha256sum hash values for
patch tarball for all the 2017 report files and display them on the
project report webpage.

Closes https://github.com/coala/projects/issues/627

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
