### PR TITLE
projects: Remove NiklasMM as mentor for all projects

### DIFF
--- a/_projects/bear-updates.md
+++ b/_projects/bear-updates.md
@@ -9,7 +9,6 @@ initiatives:
 issues: []
 markdown: bear-updates.md
 mentors:
-  - NiklasMM
   - AbdealiJK
   - mixih
 name: "Improve Lint Bear Quality"

--- a/_projects/documentation-extraction.md
+++ b/_projects/documentation-extraction.md
@@ -12,7 +12,6 @@ issues: []
 markdown: documentation-extraction.md
 mentors:
   - SanketDG
-  - NiklasMM
 name: "Documentation Extraction and Parsing"
 requirements:
   - "The participant should have one bugfix patch to any bear accepted."

--- a/_projects/nested-languages.md
+++ b/_projects/nested-languages.md
@@ -14,7 +14,6 @@ markdown: nested-languages.md
 mentors:
   - corona10
   - Udayan12167
-  - NiklasMM
 name: "Handle Nested Programming Languages"
 requirements:
   - "At least one patch to the coala core should be accepted and merged."


### PR DESCRIPTION
  As I won't be available as a mentor for coala for the
  forseeable future, I would like my name removed from
  all projects, so people don't contact me about them.

