### PR TITLE
projects.html: Add hyperlink to the mentors' name

### DIFF
--- a/partials/tabs/projects.html
+++ b/partials/tabs/projects.html
@@ -65,7 +65,11 @@ therefore adding an ignore comment -->
         <div ng-show="currentProject.difficulty" class="project-detail-element">
           <div class="small-heading uppercase">Difficulty</div> <span class="pr-element-detail chip">{{ currentProject.difficulty }}</span> </div>
         <div ng-show="currentProject.mentors.length>0" class="project-detail-element">
-          <div class="small-heading uppercase">Mentors</div> <span class="pr-element-detail chip" ng-repeat="mentor in currentProject.mentors">@{{mentor}}</span> </div>
+          <div class="small-heading uppercase">Mentors</div>
+            <span class="pr-element-detail chip" ng-repeat="mentor in currentProject.mentors">
+              <a ng-href="https://github.com/{{mentor}}" class="mentors-github-id chip" target="_blank">@{{mentor}}</a>
+            </span>
+        </div>
         <div ng-show="currentProject.developers_involved.length>0" class="project-detail-element">
           <div class="small-heading uppercase">Developers Involved</div> <span class="pr-element-detail chip" ng-repeat="developers in currentProject.developers_involved">@{{developers}}</span> </div>
         <div ng-show="currentProject.issues.length>0" class="project-detail-element">


### PR DESCRIPTION
The coala projects site https://projects.coala.io/#/projects didn't had
hyperlink to the mentors' name in the modal window of each project
description. This improvement adds hyperlink to it for convenience.

Closes https://github.com/coala/projects/issues/36

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
