### PR TITLE
students.html: Add a tab displaying GSoC Students 

### DIFF
--- a/_layouts/report.md
+++ b/_layouts/report.md
@@ -25,16 +25,18 @@
             </div>
             <br>
             <div class="row no-margin">
-                <div class="col m6">
+                <div class="col m12 l6">
                     <div class="card flex1">
                         <div class="card-content">
                             <h5 class="light no-margin"><a href="{{page.organisation_link}}">{{ page.organisation }}</a></h5>
                             <h3 class="light">{{ page.student }}</h3>
-                            <p>{{page.bio | markdownify}}</p>
+                            <div class="justify-text">
+                                <p>{{page.bio | markdownify}}</p>
+                            </div>
                         </div>
                     </div>
                 </div>
-                <div class="col m3">
+                <div class="col s6 l3">
                     <div class="card flex1">
                         <div class="card-content">
                             <div class="center"><h4 class="light no-margin">Project Title</h4></div>
@@ -46,11 +48,11 @@
                         <div class="card-content">
                             <div class="center"><h4 class="light no-margin">GSoC Blog</h4></div>
                             <br>
-                            <div class="center"><a class="blog-link" href="{{ page.blog }}">{{ page.blog }}</a></div>
+                            <div class="center break-word"><a class="blog-link" href="{{ page.blog }}">{{ page.blog }}</a></div>
                         </div>
                     </div>
                 </div>
-                <div class="col m3">
+                <div class="col s6 l3">
                     <div class="card flex1">
                         <div class="card-content links-section">
                             {% for ih in page.social %}
@@ -67,7 +69,7 @@
                             <br>
                             <div class="row no-margin center">
                                 <div class="col m3"><i class="fa fa-envelope-o"></i></div>
-                                <div class="col m9"><a href="mailto:{{ page.email }}">{{ page.email }}</a></div>
+                                <div class="col m9 break-word"><a href="mailto:{{ page.email }}">{{ page.email }}</a></div>
                             </div>
 
                         </div>
@@ -76,7 +78,7 @@
             </div>
             <br>
             <div class="row no-margin">
-                <div class="col m2">
+                <div class="col s6 m4 l2">
                     <div class="card flex1">
                         <div class="card-content">
                             <div class="center"><h5 class="light no-margin">Patches Tarball</h5></div>
@@ -95,7 +97,7 @@
                 </div>
                 {% for ih in page.phase %}
                     {% for item in ih %}
-                        <div class="col m2">
+                        <div class="col s6 m4 l2">
                             <div class="card flex1">
                                 <div class="card-content">
                                 <div class="center"><h5 class="light no-margin">{{item[0]}}</h5></div>
@@ -106,7 +108,7 @@
                         </div>
                     {% endfor %}
                 {% endfor %}
-                <div class="col m2">
+                <div class="col s6 m4 l2">
                     <div class="card flex1">
                         <div class="card-content">
                         <div class="center"><h5 class="light no-margin">Mentors</h5></div>
@@ -124,7 +126,7 @@
                 <br>
             </div>
             <div class="no-margin">
-                <table class="padding-table">
+                <table class="padding-table highlight">
                     <thead class="no-border">
                         <tr class="blue-grey-text text-lighten-2">
                             <td></td>

--- a/index.html
+++ b/index.html
@@ -52,6 +52,11 @@
               FAQs
             </a>
           </li>
+          <li ng-class="{active:nc.isSet('/students')}">
+            <a ng-click="nc.setView('/students')" onmousedown="keyPressed(event, '#/students')" onerror="">
+              GSoC Students
+            </a>
+          </li>
           <li><a href="{{ site.githuburl }}" target="_blank" title="Fork us on GitHub"><i class="fa fa-github fa-2x" aria-hidden="true"></i></a></li>
         </ul>
       </div>
@@ -60,6 +65,7 @@
       <li ng-class="{active:nc.isSet('/projects')}"><a class="uppercase" ng-click="nc.setView('/projects')" onmousedown="keyPressed(event, '#/projects')">Projects</a></li>
       <li ng-class="{active:nc.isSet('/mentors')}"><a class="uppercase" ng-click="nc.setView('/mentors')" onmousedown="keyPressed(event, '#/mentors')">Mentors</a></li>
       <li ng-class="{active:nc.isSet('/faq')}"><a ng-click="nc.setView('/faq')" onmousedown="keyPressed(event, '#/faq')" onerror="">FAQs</a></li>
+      <li ng-class="{active:nc.isSet('/students')}"><a ng-click="nc.setView('/students')" onmousedown="keyPressed(event, '#/students')" onerror="">GSoC Students</a></li>
       <li><a href="{{ site.githuburl }}" target="_blank" title="Fork us on GitHub"><i class="fa fa-github fa-2x" aria-hidden="true"></i></a></li>
     </ul>
     <div ng-view=""></div>

--- a/partials/tabs/projects.html
+++ b/partials/tabs/projects.html
@@ -9,12 +9,9 @@ therefore adding an ignore comment -->
         <input ng-model="searchText" placeholder="Search for a project" id="search" type="search" class="validate"> </div>
       <div style="text-align: center;">
         For more project ideas, <a href="https://github.com/coala/projects/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Project+Proposal%22">click here</a>.
-        <br>
-        For past years <strong>GSoC</strong> project reports, <a href="http://projects.coala.io/reports">click here</a>.
       </div>
     </div>
   </div>
-  <br>
   <br>
   <section tabindex="1">
     <div class="container">

--- a/partials/tabs/students.html
+++ b/partials/tabs/students.html
@@ -1,0 +1,60 @@
+---
+title: coala GSoC Projects Report
+---
+<!DOCTYPE html>
+<div class="main-content container-fluid">
+  <div class="row">
+    <div class="col m8 offset-m2">
+      <h1 class="fine center">Hello World!</h1>
+      <h4 class="light center">
+       The students who've participted in Google Summer of Code with {{ site.organization }}
+      </h4>
+    </div>
+  </div>
+</div>
+<div class="main-content students">
+  {% assign reportsByYear = site.reports | group_by_exp:"report", "report.date | date: '%y'" %}
+  <div class="row">
+    <div class="col s12">
+      <ul class="tabs transparent-bg">
+        {% for year in reportsByYear reversed %}
+        <li class="tab col s2"><a href="#gsoc-{{ year.name }}" class="large-font">GSoC'{{ year.name }}</a></li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% for year in reportsByYear reversed %}
+    <section id="gsoc-{{ year.name }}">
+      <div class="container">
+        <div class="row user">
+          <div class="parent-wrapper">
+            <div class="gsoc-students">
+              <div class="parent">
+                {% for report in year.items %}
+                <div class="card child card-main sc">
+                  <a href="{{ report.social[0].GitHub[1].link }}" class="gh-user" target="_blank">
+                  <div class="empty"></div>
+                  <div class="data thumbnail center" style="max-height: 150px;">
+                    <img src="https://github.com/{{ report.social[0].GitHub[0].username }}.png"
+                        alt="{{ report.student }}" class="center dp" height="100" title="{{ report.student }}"
+                        data-proofer-ignore>
+                    <div class="handle center yellow-text text-darken-4 report-url">
+                      <a href="{{ report.url }}.html">{{ report.project }}</a>
+                    </div>
+                  </div>
+                  </a>
+                </div>
+                {% endfor %}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    {% endfor %}
+  </div>
+</div>
+<script>
+$(document).ready(function () {
+    $('.students .tabs').tabs();
+})
+</script>

--- a/reports.html
+++ b/reports.html
@@ -1,25 +1,12 @@
----
-title: coala GSoC project reports
----
-
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{{ page.title }}</title>
     <meta charset="utf-8">
-    <link rel="stylesheet" href="../resources/css/style.css">
   </head>
-
-  <body class="report">
-    <h1>{{ page.title }}</h1>
-    {% assign reportsByYear = site.reports | group_by_exp:"report", "report.date | date: '%Y'" %}
-    {% for year in reportsByYear reversed %}
-      <h2>{{ year.name }}</h2>
-      <ul>
-        {% for report in year.items %}
-          <li><a href="{{ report.url }}.html">{{ report.student }}: {{ report.project }}</a></li>
-        {% endfor %}
-      </ul>
-    {% endfor %}
-  </body>
+  <body></body>
+  <script>
+      window.onload = function(){
+          window.open('/#/students', '_self');
+      };
+  </script>
 </html>

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -1,3 +1,6 @@
+.break-word {
+  word-wrap: break-word;
+}
 .hash_value_dup {
   position: 'absolute';
   left: '-9999px';
@@ -31,6 +34,12 @@
 }
 .fa-clipboard:hover .hinttext {
   visibility: visible;
+}
+.gsoc-students {
+  margin-top: 1em;
+}
+.justify-text {
+  text-align: justify;
 }
 nav {
   background-color: #37474f;
@@ -101,6 +110,9 @@ nav {
 .report .padding-table tbody tr {
   border-bottom: 1px solid aliceblue;
 }
+.report-url a {
+  color: #f57f17 !important;
+}
 @media only screen and (min-width: 993px) {
   .container {
       width: 90% !important;
@@ -123,6 +135,9 @@ nav {
 .sha256sum_hash {
   display: flex;
   justify-content: space-evenly;
+}
+.students {
+  padding: 0 20px;
 }
 .theatre .name {
   padding-left: 0.5em;

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -55,6 +55,9 @@
             when('/faq', {
                 template: '<faq></faq>'
             }).
+            when('/students', {
+                template: '<students></students>'
+            }).
             otherwise({
                 redirectTo: '/projects'
             });
@@ -413,6 +416,15 @@
 
             },
             controllerAs: "gic"
+        }
+    }]);
+
+    app.directive('students', ['$http', function ($http) {
+        return {
+            restrict: 'E',
+            templateUrl: '/partials/tabs/students.html',
+            controller: function ($scope, $rootScope) { },
+            controllerAs: "gsoc"
         }
     }]);
 


### PR DESCRIPTION
The commit replaces the reports web-page by the
students web-page. This displays all the GSoC students
using the same logic as used in reports.html for reading
all the work reports.

Closes #734